### PR TITLE
Deprecation fixes 190619

### DIFF
--- a/R/org.R
+++ b/R/org.R
@@ -222,7 +222,7 @@ invite_user = function(org, user) {
   }
 }
 
-################# Deprecated functions #################
+# Deprecated functions ---------------------------------------------------------
 
 github_api_get_repos = function(org) {
   stopifnot(length(org) == 1)

--- a/R/org.R
+++ b/R/org.R
@@ -225,10 +225,6 @@ invite_user = function(org, user) {
 ################# Deprecated functions #################
 
 github_api_get_repos = function(org) {
-
-  .Deprecated(msg = "'github_api_get_repos' will be removed in the next version. Use 'github_api_get_repo' instead.",
-              new = "github_api_get_repo")
-
   stopifnot(length(org) == 1)
   gh("GET /orgs/:org/repos", org = org, .token = get_github_token(), .limit = get_github_api_limit())
 }
@@ -276,10 +272,6 @@ get_repos = function(org, filter = NULL, exclude = FALSE, full_repo = TRUE) {
 }
 
 github_api_get_members = function(org) {
-
-  .Deprecated(msg = "'github_api_get_members' will be removed in the next version. Use 'github_api_get_member' instead.",
-              new = "github_api_get_member")
-
   stopifnot(length(org) == 1)
   safe_gh("GET /orgs/:org/members", org = org, .token = get_github_token(), .limit = get_github_api_limit())
 }
@@ -322,10 +314,6 @@ get_members = function(org, filter = NULL, exclude = FALSE) {
 }
 
 github_api_get_invitations = function(org) {
-
-  .Deprecated(msg = "'github_api_get_invitations' will be removed in the next version. Use 'github_api_get_invitation' instead.",
-              new = "github_api_get_invitation")
-
   safe_gh("GET /orgs/:org/invitations", org = org,
           .token = get_github_token(), .limit = get_github_api_limit())
 }

--- a/R/org.R
+++ b/R/org.R
@@ -256,7 +256,7 @@ github_api_get_repos = function(org) {
 #'
 get_repos = function(org, filter = NULL, exclude = FALSE, full_repo = TRUE) {
 
-  .Deprecated(msg = "'get_repos' will be removed in the next version. Use 'get_repo' instead.",
+  .Deprecated(msg = "'get_repos' is deprecated and will be removed in the next version. Use 'get_repo' instead.",
               new = "get_repo")
 
   stopifnot(length(org) == 1)
@@ -301,7 +301,7 @@ github_api_get_members = function(org) {
 #'
 get_members = function(org, filter = NULL, exclude = FALSE) {
 
-  .Deprecated(msg = "'get_members' will be removed in the next version. Use 'get_member' instead.",
+  .Deprecated(msg = "'get_members' is deprecated and will be removed in the next version. Use 'get_member' instead.",
               new = "get_member")
 
   stopifnot(length(org) == 1)
@@ -342,7 +342,7 @@ github_api_get_invitations = function(org) {
 #'
 get_pending_members = function(org, filter = NULL, exclude = FALSE) {
 
-  .Deprecated(msg = "'get_pending_members' will be removed in the next version. Use 'get_pending_member' instead.",
+  .Deprecated(msg = "'get_pending_members' is deprecated and will be removed in the next version. Use 'get_pending_member' instead.",
               new = "get_pending_member")
 
   stopifnot(length(org) == 1)

--- a/R/repo.R
+++ b/R/repo.R
@@ -684,7 +684,7 @@ github_api_get_collaborators = function(repo) {
 #'
 get_repo_collaborators = function(repo) {
 
-  .Deprecated(msg = "'get_repo_collaborators' will be removed in the next version. Use 'get_collaborators' instead.",
+  .Deprecated(msg = "'get_repo_collaborators' is deprecated and will be removed in the next version. Use 'get_collaborators' instead.",
               new = "get_collaborator")
 
   users = purrr::map(
@@ -712,7 +712,7 @@ get_repo_collaborators = function(repo) {
 #'
 check_repos = function(repos)
 {
-  .Deprecated(msg = "'check_repos' will be removed in the next version. Use 'check_repo' instead.",
+  .Deprecated(msg = "'check_repos' is deprecated and will be removed in the next version. Use 'check_repo' instead.",
               new = "check_repo")
 
   exists = function(owner, repo)
@@ -760,7 +760,7 @@ github_api_get_admins = function(org){
 #'
 get_admins = function(org, verbose = FALSE) {
 
-  .Deprecated(msg = "'get_admins' will be removed in the next version. Use 'get_admin' instead.",
+  .Deprecated(msg = "'get_admins' is deprecated and will be removed in the next version. Use 'get_admin' instead.",
               new = "get_admin")
 
   purrr::map(
@@ -797,7 +797,7 @@ get_admins = function(org, verbose = FALSE) {
 #'
 get_collaborators = function(repo, include_admins = TRUE, verbose = FALSE) {
 
-  .Deprecated(msg = "'get_collaborators' will be removed in the next version. Use 'get_collaborator' instead.",
+  .Deprecated(msg = "'get_collaborators' is deprecated and will be removed in the next version. Use 'get_collaborator' instead.",
               new = "get_collaborator")
 
   stopifnot(!missing(repo))
@@ -817,48 +817,3 @@ get_collaborators = function(repo, include_admins = TRUE, verbose = FALSE) {
     }
   )
 }
-#' List collaborators
-#'
-#' `get_collaborators` Returns a vector of collaborator user names. Users with Admin rights are by default excluded, but can be included manually.
-#'
-#' @param repo Character. Address of repository in "owner/name" format.
-#' @param include_admins Logical. If FALSE, user names of users with Admin rights are not included. Default is TRUE.
-#' @param verbose Logical. Display verbose output.
-#'
-#' @return A list containing a character vector of user names.
-#'
-#' @templateVar fun get_collaborators
-#' @template template-depr_fun
-#'
-#' @templateVar old get_collaborators
-#' @templateVar new get_collaborator
-#' @template template-depr_pkg
-#'
-#' @examples
-#' \dontrun{
-#' get_collaborators("Sta523-Fa17")
-#' }
-#'
-get_collaborators = function(repo, include_admins = TRUE, verbose = FALSE) {
-
-  .Deprecated(msg = "'get_collaborators' will be removed in the next version. Use 'get_collaborator' instead.",
-              new = "get_collaborator")
-
-  stopifnot(!missing(repo))
-
-  admins = list(NULL)
-  if (!include_admins)
-    admins = get_admins(get_repo_owner(repo))
-
-  purrr::map2(
-    repo, admins,
-    function(repo, admins) {
-      res = github_api_get_collaborators(repo)
-
-      check_result(res, sprintf("Unable to retrieve collaborators for %s.", repo), verbose)
-
-      setdiff(purrr::map_chr(res$result, "login"), admins)
-    }
-  )
-}
-

--- a/R/repo.R
+++ b/R/repo.R
@@ -653,10 +653,6 @@ get_collaborator = function(repo, include_admin = TRUE, verbose = FALSE) {
 
 ################ Deprecated functions ################
 github_api_get_collaborators = function(repo) {
-
-  .Deprecated(msg = "'github_api_get_collaborators' will be removed in the next version. Use 'github_api_get_collaborator' instead.",
-              new = "github_api_get_collaborator")
-
   safe_gh(
     "GET /repos/:owner/:repo/collaborators",
     owner = get_repo_owner(repo),
@@ -733,10 +729,6 @@ check_repos = function(repos)
 
 
 github_api_get_admins = function(org){
-
-  .Deprecated(msg = "'github_api_get_admins' will be removed in the next version. Use 'github_api_get_admin' instead.",
-              new = "github_api_get_admin")
-
   safe_gh("GET /orgs/:org/members",
           org = org,
           role = "admin",

--- a/R/repo.R
+++ b/R/repo.R
@@ -651,7 +651,8 @@ get_collaborator = function(repo, include_admin = TRUE, verbose = FALSE) {
   )
 }
 
-################ Deprecated functions ################
+# Deprecated functions ---------------------------------------------------------
+
 github_api_get_collaborators = function(repo) {
   safe_gh(
     "GET /repos/:owner/:repo/collaborators",

--- a/R/repo_files.R
+++ b/R/repo_files.R
@@ -382,7 +382,7 @@ add_file = function(repo, file, message = NULL, branch = "master", preserve_path
 #'
 add_files = function(repo, message, files, branch = "master", preserve_path = FALSE)
 {
-  .Deprecated(msg = "'add_files' will be removed in the next version. Use 'add_file' instead.",
+  .Deprecated(msg = "'add_files' is deprecated and will be removed in the next version. Use 'add_file' instead.",
               new = "add_file")
 
   stopifnot(!missing(repo))

--- a/R/repo_files.R
+++ b/R/repo_files.R
@@ -350,7 +350,7 @@ add_file = function(repo, file, message = NULL, branch = "master", preserve_path
 }
 
 
-################# Deprecated functions ###################
+# Deprecated functions ---------------------------------------------------------
 
 #' Add files to a repo
 #'

--- a/man/get_collaborators-deprecated.Rd
+++ b/man/get_collaborators-deprecated.Rd
@@ -6,16 +6,8 @@
 \title{List collaborators}
 \usage{
 get_collaborators(repo, include_admins = TRUE, verbose = FALSE)
-
-get_collaborators(repo, include_admins = TRUE, verbose = FALSE)
 }
 \arguments{
-\item{repo}{Character. Address of repository in "owner/name" format.}
-
-\item{include_admins}{Logical. If FALSE, user names of users with Admin rights are not included. Default is TRUE.}
-
-\item{verbose}{Logical. Display verbose output.}
-
 \item{repo}{Character. Address of repository in "owner/name" format.}
 
 \item{include_admins}{Logical. If FALSE, user names of users with Admin rights are not included. Default is TRUE.}
@@ -24,18 +16,11 @@ get_collaborators(repo, include_admins = TRUE, verbose = FALSE)
 }
 \value{
 A list containing a character vector of user names.
-
-A list containing a character vector of user names.
 }
 \description{
 \code{get_collaborators} Returns a vector of collaborator user names. Users with Admin rights are by default excluded, but can be included manually.
-
-\code{get_collaborators} Returns a vector of collaborator user names. Users with Admin rights are by default excluded, but can be included manually.
 }
 \section{\code{get_collaborators}}{
-
-For \code{get_collaborators}, use \code{\link{get_collaborator}}.
-
 
 For \code{get_collaborators}, use \code{\link{get_collaborator}}.
 }
@@ -45,14 +30,8 @@ For \code{get_collaborators}, use \code{\link{get_collaborator}}.
 get_collaborators("Sta523-Fa17")
 }
 
-\dontrun{
-get_collaborators("Sta523-Fa17")
-}
-
 }
 \seealso{
-\code{\link{ourPkg-deprecated}}
-
 \code{\link{ourPkg-deprecated}}
 }
 \keyword{internal}


### PR DESCRIPTION
Fixes #38 
- Removes deprecation messages from `github_api_*` functions.
- Changes wording of deprecation messages to "OLD FUNCTION is deprecated and will be removed in the next version. Use NEW FUNCTION instead. "
- removes duplicate `get_collaborators` function.