### PR TITLE
Adding verbose statement to `find_file`

### DIFF
--- a/R/repo_files.R
+++ b/R/repo_files.R
@@ -144,7 +144,7 @@ github_api_code_search = function(query) {
 }
 
 
-find_file = function(repo, file){
+find_file = function(repo, file, verbose = T){
   arg_is_chr_scalar(repo)
   arg_is_chr(file)
 
@@ -160,7 +160,7 @@ find_file = function(repo, file){
 
         if(res[["total_count"]] > 0){
           purrr::map_chr(res[["items"]], "path")
-        } else {
+        } else if(verbose){
           usethis::ui_oops("Cannot find file {usethis::ui_value(file)} on {usethis::ui_value(repo)}.")
         }
       }

--- a/R/repo_files.R
+++ b/R/repo_files.R
@@ -144,7 +144,7 @@ github_api_code_search = function(query) {
 }
 
 
-find_file = function(repo, file, verbose = T){
+find_file = function(repo, file, verbose = TRUE){
   arg_is_chr_scalar(repo)
   arg_is_chr(file)
 
@@ -160,7 +160,7 @@ find_file = function(repo, file, verbose = T){
 
         if(res[["total_count"]] > 0){
           purrr::map_chr(res[["items"]], "path")
-        } else if(verbose){
+        } else if (verbose){
           usethis::ui_oops("Cannot find file {usethis::ui_value(file)} on {usethis::ui_value(repo)}.")
         }
       }


### PR DESCRIPTION
`verbose` defaults to `TRUE`. Setting `verbose = F` allows functions calling `find_file` to be less chatty (as used in the peer review functions I am currently working on).