### PR TITLE
Adding verbose parameter to file_exists

### DIFF
--- a/R/repo_files.R
+++ b/R/repo_files.R
@@ -169,12 +169,12 @@ find_file = function(repo, file, verbose = TRUE){
 }
 
 
-file_exists = function(repo, file, branch = "master") {
+file_exists = function(repo, file, branch = "master", verbose = TRUE) {
   purrr::pmap_lgl(
     list(repo, file, branch),
     function(repo, file, branch) {
       if (branch == "master") {
-        (length(find_file(repo,file)) > 0)
+        (length(find_file(repo, file, verbose)) > 0)
       } else {
         # Only the master branch is indexed for search
         is.null(get_file(repo, file, branch))


### PR DESCRIPTION
Minor change to allow the new `verbose` parameter from `find_file` to be controlled from `file_exists`.