### PR TITLE
Enhancements for repo_add_user examples

### DIFF
--- a/R/repo_add_user.R
+++ b/R/repo_add_user.R
@@ -21,7 +21,11 @@ github_api_add_user = function(repo, username, permission){
 #'
 #' @examples
 #' \dontrun{
-#' repo_add_user("ghclass-test/hw1-user01", c("user01", "user02"))
+#' repo_add_user("ghclass-test/hw1-team1", c("user01", "user02"))
+#'
+#' ## Adding users to their individual repositories
+#' user = c("user01", "user02")
+#' repo_add_user(paste0("ghclass-test/hw2-", user), user)
 #' }
 #'
 #' @rdname repo_add_member

--- a/docs/reference/repo_add_member.html
+++ b/docs/reference/repo_add_member.html
@@ -139,7 +139,11 @@ Note that permissions will overwrite existing access privileges.</p></td>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><span class='co'># NOT RUN {</span>
-<span class='fu'>repo_add_user</span>(<span class='st'>"ghclass-test/hw1-user01"</span>, <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"user01"</span>, <span class='st'>"user02"</span>))
+<span class='fu'>repo_add_user</span>(<span class='st'>"ghclass-test/hw1-team1"</span>, <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"user01"</span>, <span class='st'>"user02"</span>))
+
+<span class='co'>## Adding users to their individual repositories</span>
+<span class='no'>user</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"user01"</span>, <span class='st'>"user02"</span>)
+<span class='fu'>repo_add_user</span>(<span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/paste'>paste0</a></span>(<span class='st'>"ghclass-test/hw2-"</span>, <span class='no'>user</span>), <span class='no'>user</span>)
 <span class='co'># }</span><div class='input'>
 </div></pre>
   </div>

--- a/man/repo_add_member.Rd
+++ b/man/repo_add_member.Rd
@@ -29,7 +29,11 @@ Add a user or team to a repository
 }
 \examples{
 \dontrun{
-repo_add_user("ghclass-test/hw1-user01", c("user01", "user02"))
+repo_add_user("ghclass-test/hw1-team1", c("user01", "user02"))
+
+## Adding users to their individual repositories
+user = c("user01", "user02")
+repo_add_user(paste0("ghclass-test/hw2-", user), user)
 }
 
 }


### PR DESCRIPTION
The PR adds an example for how to add students to individual repositories that contain their GitHub user name in the repository name (a common use case). It also changes the existing example to mimic adding multiple students to a team repo.