### PR TITLE
Fixing `issue_create()` bug

### DIFF
--- a/R/issue_create.R
+++ b/R/issue_create.R
@@ -5,8 +5,8 @@ github_api_issue_create = function(repo, title, body, labels, assignees){
     repo = get_repo_name(repo),
     title = title,
     body = body,
-    labels = labels,
-    assignees = assignees,
+    labels = as.list(labels),
+    assignees = as.list(assignees),
     .token = github_get_token()
   )
 }
@@ -28,12 +28,11 @@ issue_create = function(repo, title, body, labels = character(), assignees = cha
 
   arg_is_chr(repo, title, body)
 
-  if (!is.list(labels))
-    labels = list(labels)
+  if (is.list(labels))
+    labels = unlist(labels)
 
-  if (!is.list(assignees))
-    assignees = list(assignees)
-
+  if (is.list(assignees))
+    assignees = unlist(assignees)
 
   res = purrr::pmap(
     list(repo, title, body, labels, assignees),


### PR DESCRIPTION
This PR is fixing a bug with `issue_create()`, see  #93. 

The `labels` and `assignee` fields in `github_api_issue_create()` expect array. This gets messed up by `pmap()` when being passed as a list to `github_api_issue_create()`. 

Fixed by passing `labels` and `assignee` as a list to `github_api_issue_create()`.