### PR TITLE
Better handling of issue creation

### DIFF
--- a/R/issue_create.R
+++ b/R/issue_create.R
@@ -21,6 +21,24 @@ github_api_issue_create = function(repo, title, body, labels, assignees){
 #' @param labels Character. Vector of the labels to associate with this issue
 #' @param assignees Character. Vector of logins for users assigned to the issue.
 #'
+#' @examplesIf FALSE
+#' repo_create("ghclass-test","issue-test")
+#'
+#' issue_create("ghclass-test/issue-test", title = "Issue 1", body = "This is an issue")
+#'
+#' issue_create(
+#'   "ghclass-test/issue-test",
+#'   title = "Issue 2", body = "This is also issue",
+#'   label = "Important"
+#' )
+#'
+#' issue_create(
+#'   "ghclass-test/issue-test",
+#'   title = "Issue 3", body = "This is also issue",
+#'   label = c("Important", "Super Important")
+#'   assignees = "rundel"
+#' )
+#'
 #' @export
 #'
 
@@ -33,7 +51,6 @@ issue_create = function(repo, title, body, labels = character(), assignees = cha
 
   if (!is.list(assignees))
     assignees = list(assignees)
-
 
   res = purrr::pmap(
     list(repo, title, body, labels, assignees),

--- a/R/issue_create.R
+++ b/R/issue_create.R
@@ -5,8 +5,8 @@ github_api_issue_create = function(repo, title, body, labels, assignees){
     repo = get_repo_name(repo),
     title = title,
     body = body,
-    labels = labels,
-    assignees = assignees,
+    labels = I(labels),
+    assignees = I(assignees),
     .token = github_get_token()
   )
 }


### PR DESCRIPTION
Small tweak to `github_api_issue_create` which should hopefully better handle tagging labels and assignees - can now provide either a list or a character vector.

@thereseanders can you tweak your code in the peer review section to use this version and add it to this PR?