### PR TITLE
Fix logic bug for multiple file addition

### DIFF
--- a/R/local_repo_add.R
+++ b/R/local_repo_add.R
@@ -9,7 +9,7 @@ local_repo_add = function(repo_dir, files = ".") {
   res = purrr::map(
     repo_dir,
     function(dir) {
-      if (files == ".") {
+      if (identical(files, ".")) {
         files = gert::git_status(repo = dir)[["file"]]
       }
 


### PR DESCRIPTION
If more than one file is specified, if (files == ".") fails due to invalid vector if-logic. Changed to identical(files, ".") to correctly capture the intended default setting.

Also related to https://github.com/rundel/ghclass/issues/125
